### PR TITLE
Scala Fibonacci CLI

### DIFF
--- a/fibonacci-sequence/README.md
+++ b/fibonacci-sequence/README.md
@@ -6,3 +6,12 @@ These were contributed on April 30th, 2015
 
 simply run `$ sh rfair404_fibonacci.sh`
 
+
+### justanr_fibonacci.scala
+
+```
+scalac justanr_fibonacci.scala
+scala Fibonacci n
+```
+
+Where n is the number of Fibonacci numbers you'd like to see.

--- a/fibonacci-sequence/justanr_fibonacci.scala
+++ b/fibonacci-sequence/justanr_fibonacci.scala
@@ -1,0 +1,10 @@
+object Fibonacci {
+  val fib: Stream[Long] = {
+    def fibs(h: Long, n: Long): Stream[Long] = h #:: fibs(n, h+n)
+    fibs(0, 1)
+  }
+  def main(args: Array[String]) = {
+    val takeTo = args(0).toInt
+    fib.take(takeTo).toList.foreach(println)
+  }
+}


### PR DESCRIPTION
Recursive Fibonacci stream in Scala. It starts overflowing around the 94th number, however. Probably should've used BigInt instead.
